### PR TITLE
Convert service point to array.

### DIFF
--- a/src/Resources/ServicePoint.php
+++ b/src/Resources/ServicePoint.php
@@ -76,4 +76,21 @@ class ServicePoint extends Address
             $this->longitude = $collection->get('longitude');
         });
     }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return collect(parent::toArray())
+            ->merge([
+                'distance' => $this->distanceForHumans()
+            ])
+            ->reject(function ($value) {
+                return empty($value);
+            })
+            ->all();
+    }
 }

--- a/tests/Unit/Resources/ServicePointTest.php
+++ b/tests/Unit/Resources/ServicePointTest.php
@@ -73,4 +73,46 @@ class ServicePointTest extends TestCase
         $servicepoint->distance = 11500;
         $this->assertEquals('12 km', $servicepoint->distanceForHumans());
     }
+
+    /** @test */
+    public function to_array()
+    {
+        $servicepoint = new ServicePoint([
+            'id' => 'testcode1234',
+            'name' => 'Test name',
+            'latitude' => 1.11,
+            'longitude' => 2.22,
+            'distance' => 100,
+        ]);
+
+        $array = $servicepoint->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEquals('testcode1234', $array['id']);
+        $this->assertEquals('Test name', $array['name']);
+        $this->assertEquals(1.11, $array['latitude']);
+        $this->assertEquals(2.22, $array['longitude']);
+        $this->assertEquals('100 meter', $array['distance']);
+    }
+
+    /** @test */
+    public function to_array_removes_empty_attributes()
+    {
+        $servicepoint = new ServicePoint([
+            'id' => null,
+            'name' => 'Test name',
+            'latitude' => null,
+            'longitude' => null,
+            'distance' => null,
+        ]);
+
+        $array = $servicepoint->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayNotHasKey('id', $array);
+        $this->assertEquals('Test name', $array['name']);
+        $this->assertArrayNotHasKey('latitude', $array);
+        $this->assertArrayNotHasKey('longitude', $array);
+        $this->assertArrayNotHasKey('distance', $array);
+    }
 }


### PR DESCRIPTION
- Removes empty attributes when calling the toArray() method on a `ServicePoint` object.
- Adds distance in human readable format when calling the toArray() method on a `ServicePoint` object.