### PR TITLE
Use company as an alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $parcel = new \Mvdnbrk\DhlParcel\Resources\Parcel([
         'cc' => 'NL',
     ],
     'sender' => [
-        'company' => 'Your Company',
+        'company_name' => 'Your Company Name',
         'street' => 'Pakketstraat',
         'number' => '99',
         'postal_code' => '9999AA',

--- a/src/Resources/Recipient.php
+++ b/src/Resources/Recipient.php
@@ -7,7 +7,7 @@ class Recipient extends Address
     /**
      * @var string
      */
-    public $company;
+    public $company_name;
 
     /**
      * @var string
@@ -30,6 +30,17 @@ class Recipient extends Address
     public $phone;
 
     /**
+     * Set the company. Alias for company_name.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setCompanyAttribute($value)
+    {
+        $this->company_name = $value;
+    }
+
+    /**
      * Convert the "address" part of the recipient to an array.
      *
      * @return array
@@ -38,13 +49,13 @@ class Recipient extends Address
     {
         return collect(parent::toArray())
             ->diffKeys([
-                'company' => '',
+                'company_name' => '',
                 'first_name' => '',
                 'last_name' => '',
                 'email' => '',
                 'phone' => '',
             ])
-            ->when(! empty($this->company), function ($collection) {
+            ->when(! empty($this->company_name), function ($collection) {
                 return $collection->put('isBusiness', true);
             })
             ->all();
@@ -60,7 +71,7 @@ class Recipient extends Address
         return collect([
                 'firstName' => $this->first_name,
                 'lastName' => $this->last_name,
-                'companyName' => $this->company,
+                'companyName' => $this->company_name,
             ])
             ->filter()
             ->all();

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -64,7 +64,7 @@ class ParcelTest extends TestCase
         $this->assertEquals('test-123', $parcel->reference);
         $this->assertEquals('John', $parcel->recipient->first_name);
         $this->assertEquals('Doe', $parcel->recipient->last_name);
-        $this->assertEquals('Test Company B.V.', $parcel->sender->company);
+        $this->assertEquals('Test Company B.V.', $parcel->sender->company_name);
         $this->assertEquals('Test 123', $parcel->options->label_description);
         $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $parcel->pieces->pieces[0]->parcel_type);
         $this->assertEquals(1, $parcel->pieces->pieces[0]->quantity);
@@ -86,7 +86,7 @@ class ParcelTest extends TestCase
             'recipient' => $recipient,
         ]);
 
-        $this->assertEquals('Test Company B.V.', $parcel->recipient->company);
+        $this->assertEquals('Test Company B.V.', $parcel->recipient->company_name);
         $this->assertEquals('John', $parcel->recipient->first_name);
         $this->assertEquals('Doe', $parcel->recipient->last_name);
     }

--- a/tests/Unit/Resources/RecipientTest.php
+++ b/tests/Unit/Resources/RecipientTest.php
@@ -29,7 +29,7 @@ class RecipientTest extends TestCase
             'phone' => '0101111111',
         ]);
 
-        $this->assertEquals('Test Company B.V.', $recipient->company);
+        $this->assertEquals('Test Company B.V.', $recipient->company_name);
         $this->assertEquals('John', $recipient->first_name);
         $this->assertEquals('Doe', $recipient->last_name);
         $this->assertEquals('john@example.com', $recipient->email);

--- a/tests/Unit/Resources/RecipientTest.php
+++ b/tests/Unit/Resources/RecipientTest.php
@@ -10,7 +10,7 @@ class RecipientTest extends TestCase
     private function validParams($overrides = [])
     {
         return array_merge([
-            'company' => 'Test Company B.V.',
+            'company_name' => 'Test Company B.V.',
             'first_name' => 'John',
             'last_name' => 'Doe',
             'email' => 'john@example.com',
@@ -22,7 +22,7 @@ class RecipientTest extends TestCase
     public function creating_a_valid_recipient_resource()
     {
         $recipient = new Recipient([
-            'company' => 'Test Company B.V.',
+            'company_name' => 'Test Company B.V.',
             'first_name' => 'John',
             'last_name' => 'Doe',
             'email' => 'john@example.com',
@@ -40,7 +40,7 @@ class RecipientTest extends TestCase
     public function to_array()
     {
         $attributes = [
-            'company' => 'Test Company B.V.',
+            'company_name' => 'Test Company B.V.',
             'first_name' => 'John',
             'last_name' => 'Doe',
             'email' => 'john@example.com',
@@ -83,12 +83,22 @@ class RecipientTest extends TestCase
 
         $recipient->email = null;
         $recipient->phone = null;
-        $recipient->company = null;
+        $recipient->company_name = null;
         $array = $recipient->toArray();
         $this->assertArrayNotHasKey('email', $array);
         $this->assertArrayNotHasKey('phone', $array);
         $this->assertArrayNotHasKey('phoneNumber', $array);
         $this->assertArrayNotHasKey('companyName', $array['name']);
         $this->assertFalse($array['address']['isBusiness']);
+    }
+
+    /** @test */
+    public function company_may_be_used_as_an_alias_to_company_name()
+    {
+        $recipient = new Recipient([
+            'company' => 'Test Company B.V.',
+        ]);
+
+        $this->assertEquals('Test Company B.V.', $recipient->company_name);
     }
 }


### PR DESCRIPTION
Replaces the public property `company` to `company_name` to follow the naming conventions of the DHL Parcel API.

Added an alias for `company` with the `setCompanyAttribute` method for backwards compatibility.