### PR TITLE
Adds camel string helper.

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -5,11 +5,32 @@ namespace Mvdnbrk\DhlParcel\Support;
 class Str
 {
     /**
+     * The cache of camel-cased words.
+     *
+     * @var array
+     */
+    protected static $camelCache = [];
+
+    /**
      * The cache of studly-cased words.
      *
      * @var array
      */
     protected static $studlyCache = [];
+
+    /**
+     * Convert a value to camel case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function camel($value)
+    {
+        if (isset(static::$camelCache[$value])) {
+            return static::$camelCache[$value];
+        }
+        return static::$camelCache[$value] = lcfirst(static::studly($value));
+    }
 
     /**
      * Limit the number of characters in a string.

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -29,6 +29,7 @@ class Str
         if (isset(static::$camelCache[$value])) {
             return static::$camelCache[$value];
         }
+
         return static::$camelCache[$value] = lcfirst(static::studly($value));
     }
 

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -8,6 +8,21 @@ use Mvdnbrk\DhlParcel\Tests\TestCase;
 class StrTest extends TestCase
 {
     /** @test */
+    public function camel()
+    {
+        $this->assertSame('loremPHPIpsum', Str::camel('Lorem_p_h_p_ipsum'));
+        $this->assertSame('loremPhpIpsum', Str::camel('Lorem_php_ipsum'));
+        $this->assertSame('loremPhPIpsum', Str::camel('Lorem-phP-ipsum'));
+        $this->assertSame('loremPhpIpsum', Str::camel('Lorem  -_-  php   -_-   ipsum   '));
+        $this->assertSame('fooBar', Str::camel('FooBar'));
+        $this->assertSame('fooBar', Str::camel('foo_bar'));
+        // test cache
+        $this->assertSame('fooBar', Str::camel('foo_bar'));
+        $this->assertSame('fooBarBaz', Str::camel('Foo-barBaz'));
+        $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
+    }
+
+    /** @test */
     public function limit()
     {
         $this->assertEquals('Lorem', Str::limit('Lorem', 5));


### PR DESCRIPTION
This PR adds a camel string helper.

This can make the process of converting properties of resource classes to camel case easier when we need to send them to the DHL parcel API endpoint.

For example:
```php
Str::camel('foo_bar');
// fooBar
```

Related to PR #22 