### PR TITLE
Adds snake string helper.

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -5,6 +5,13 @@ namespace Mvdnbrk\DhlParcel\Support;
 class Str
 {
     /**
+     * The cache of snake-cased words.
+     *
+     * @var array
+     */
+    protected static $snakeCache = [];
+
+    /**
      * The cache of studly-cased words.
      *
      * @var array
@@ -26,6 +33,40 @@ class Str
         }
 
         return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+    }
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function lower($value)
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    /**
+     * Convert a string to snake case.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function snake($value, $delimiter = '_')
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
+        }
+
+        if (! ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', ucwords($value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+        }
+
+        return static::$snakeCache[$key][$delimiter] = $value;
     }
 
     /**

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -16,6 +16,32 @@ class StrTest extends TestCase
     }
 
     /** @test */
+    public function lower()
+    {
+        $this->assertSame('foo bar baz', Str::lower('FOO BAR BAZ'));
+        $this->assertSame('foo bar baz', Str::lower('fOo Bar bAz'));
+    }
+
+    /** @test */
+    public function snake()
+    {
+        $this->assertSame('lorem_p_h_p_ipsum', Str::snake('LoremPHPIpsum'));
+        $this->assertSame('lorem_php_ipsum', Str::snake('LoremPhpIpsum'));
+        $this->assertSame('lorem php ipsum', Str::snake('LoremPhpIpsum', ' '));
+        $this->assertSame('lorem_php_ipsum', Str::snake('Lorem Php Ipsum'));
+        $this->assertSame('lorem_php_ipsum', Str::snake('Lorem    Php      Ipsum   '));
+        $this->assertSame('lorem__php__ipsum', Str::snake('LoremPhpIpsum', '__'));
+        $this->assertSame('lorem_php_ipsum_', Str::snake('LoremPhpIpsum_', '_'));
+        $this->assertSame('lorem_php_ipsum', Str::snake('lorem php Ipsum'));
+        $this->assertSame('lorem_php_ipsum_dolet', Str::snake('lorem php IpsumDolet'));
+
+        $this->assertSame('foo-bar', Str::snake('foo-bar'));
+        $this->assertSame('foo-_bar', Str::snake('Foo-Bar'));
+        $this->assertSame('foo__bar', Str::snake('Foo_Bar'));
+        $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
+    }
+
+    /** @test */
     public function studly()
     {
         $this->assertSame('LoremPHPIpsum', Str::studly('lorem_p_h_p_ipsum'));


### PR DESCRIPTION
This PR adds a snake string helper.

When consuming a response from the DHL parcel API we can use this helper to convert the properties from the JSON response back to snake case to fill our resource classes.

For example:
```php
Str::snake('fooBar');
// foo_bar
```

Related to PR #21  