### PR TITLE
Add a ShouldAuthenticate contract.

### DIFF
--- a/src/Contracts/ShouldAuthenticate.php
+++ b/src/Contracts/ShouldAuthenticate.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mvdnbrk\DhlParcel\Contracts;
+
+interface ShouldAuthenticate
+{
+    //
+}

--- a/src/Endpoints/BaseEndpoint.php
+++ b/src/Endpoints/BaseEndpoint.php
@@ -3,6 +3,7 @@
 namespace Mvdnbrk\DhlParcel\Endpoints;
 
 use Mvdnbrk\DhlParcel\Client;
+use Mvdnbrk\DhlParcel\Contracts\ShouldAuthenticate;
 use Mvdnbrk\DhlParcel\Exceptions\DhlParcelException;
 
 abstract class BaseEndpoint
@@ -11,13 +12,6 @@ abstract class BaseEndpoint
      * @var \Mvdnbrk\DhlParcel\Client
      */
     protected $apiClient;
-
-    /**
-     * Indicates if this endpoint needs authentication.
-     *
-     * @var bool
-     */
-    protected $mustAuthenticate = false;
 
     /**
      * Create an endpoint instance.
@@ -59,7 +53,7 @@ abstract class BaseEndpoint
     protected function requestHeaders($headers)
     {
         return collect($headers)
-            ->when($this->mustAuthenticate, function ($collection) {
+            ->when($this instanceof ShouldAuthenticate, function ($collection) {
                 return $collection->merge([
                     'Authorization' => 'Bearer '.$this->apiClient->authentication->getAccessToken()->token,
                 ]);

--- a/src/Endpoints/Labels.php
+++ b/src/Endpoints/Labels.php
@@ -2,17 +2,11 @@
 
 namespace Mvdnbrk\DhlParcel\Endpoints;
 
+use Mvdnbrk\DhlParcel\Contracts\ShouldAuthenticate;
 use Mvdnbrk\DhlParcel\Resources\Shipment;
 
-class Labels extends BaseEndpoint
+class Labels extends BaseEndpoint implements ShouldAuthenticate
 {
-    /**
-     * Indicates if this endpoint needs authentication.
-     *
-     * @var bool
-     */
-    protected $mustAuthenticate = true;
-
     /**
      * Get a shipment label by shipment id.
      *

--- a/src/Endpoints/Shipments.php
+++ b/src/Endpoints/Shipments.php
@@ -2,19 +2,13 @@
 
 namespace Mvdnbrk\DhlParcel\Endpoints;
 
+use Mvdnbrk\DhlParcel\Contracts\ShouldAuthenticate;
 use Mvdnbrk\DhlParcel\Resources\Parcel;
 use Mvdnbrk\DhlParcel\Resources\Shipment as ShipmentResource;
 use Ramsey\Uuid\Uuid;
 
-class Shipments extends BaseEndpoint
+class Shipments extends BaseEndpoint implements ShouldAuthenticate
 {
-    /**
-     * Indicates if this endpoint needs authentication.
-     *
-     * @var bool
-     */
-    protected $mustAuthenticate = true;
-
     /**
      * Create a new shipment for a parcel.
      *


### PR DESCRIPTION
This PR adds a `ShoudlAuthenticate` contract, which replaces the use of the `mustAuthenticate` attribute.

An API endpoint that needs authentication should implement this contract.
