### PR TITLE
Updates Shipment.

### DIFF
--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -2,7 +2,7 @@
 
 namespace Mvdnbrk\DhlParcel\Resources;
 
-class Shipment extends Parcel
+class Shipment extends BaseResource
 {
     /**
      * @var int


### PR DESCRIPTION
@jacobdekeizer I thought the `Shipments` endpoint would return the parcel information as well.
Seems like it doesn't. May have changed or may be documented wrong in the past. 

However there is no need to extend the `Shipment` resource from the `Parcel` class anymore.