### PR TITLE
Cast properties to integer.

### DIFF
--- a/src/Resources/Piece.php
+++ b/src/Resources/Piece.php
@@ -69,6 +69,17 @@ class Piece extends BaseResource
     }
 
     /**
+     * Set the weight
+     *
+     * @param  int  $value
+     * @return void
+     */
+    public function setWeightAttribute(int $value)
+    {
+        $this->weight = $value;
+    }
+
+    /**
      * Convert the Piece resource to an array.
      *
      * @return array

--- a/src/Resources/Piece.php
+++ b/src/Resources/Piece.php
@@ -58,7 +58,7 @@ class Piece extends BaseResource
     }
 
     /**
-     * Set the quantity
+     * Set the quantity.
      *
      * @param  int  $value
      * @return void
@@ -69,7 +69,7 @@ class Piece extends BaseResource
     }
 
     /**
-     * Set the weight
+     * Set the weight.
      *
      * @param  int  $value
      * @return void

--- a/src/Resources/Piece.php
+++ b/src/Resources/Piece.php
@@ -58,6 +58,17 @@ class Piece extends BaseResource
     }
 
     /**
+     * Set the quantity
+     *
+     * @param  int  $value
+     * @return void
+     */
+    public function setQuantityAttribute(int $value)
+    {
+        $this->quantity = $value;
+    }
+
+    /**
      * Convert the Piece resource to an array.
      *
      * @return array

--- a/tests/Unit/Resources/PieceTest.php
+++ b/tests/Unit/Resources/PieceTest.php
@@ -13,7 +13,7 @@ class PieceTest extends TestCase
         $piece = new Piece;
 
         $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $piece->parcel_type);
-        $this->assertEquals(1, $piece->quantity);
+        $this->assertSame(1, $piece->quantity);
         $this->assertNull($piece->weight);
     }
 
@@ -27,8 +27,19 @@ class PieceTest extends TestCase
         ]);
 
         $this->assertEquals(Piece::PARCEL_TYPE_MEDIUM, $piece->parcel_type);
-        $this->assertEquals(2, $piece->quantity);
         $this->assertEquals(3, $piece->weight);
+        $this->assertSame(2, $piece->quantity);
+    }
+
+    /** @test */
+    public function quantity_should_be_casted_to_an_integer()
+    {
+        $piece = new Piece([
+            'quantity' => '1',
+        ]);
+
+        $this->assertSame(1, $piece->quantity);
+        $this->assertSame(1, $piece->toArray()['quantity']);
     }
 
     /** @test */
@@ -45,7 +56,7 @@ class PieceTest extends TestCase
         $this->assertIsArray($array);
         $this->assertEquals('LARGE', $array['parcelType']);
         $this->assertArrayNotHasKey('parcel_type', $array);
-        $this->assertEquals(10, $array['quantity']);
         $this->assertEquals(20, $array['weight']);
+        $this->assertSame(10, $array['quantity']);
     }
 }

--- a/tests/Unit/Resources/PieceTest.php
+++ b/tests/Unit/Resources/PieceTest.php
@@ -27,8 +27,8 @@ class PieceTest extends TestCase
         ]);
 
         $this->assertEquals(Piece::PARCEL_TYPE_MEDIUM, $piece->parcel_type);
-        $this->assertEquals(3, $piece->weight);
         $this->assertSame(2, $piece->quantity);
+        $this->assertSame(3, $piece->weight);
     }
 
     /** @test */
@@ -40,6 +40,17 @@ class PieceTest extends TestCase
 
         $this->assertSame(1, $piece->quantity);
         $this->assertSame(1, $piece->toArray()['quantity']);
+    }
+
+    /** @test */
+    public function weight_should_be_casted_to_an_integer()
+    {
+        $piece = new Piece([
+            'weight' => '1',
+        ]);
+
+        $this->assertSame(1, $piece->weight);
+        $this->assertSame(1, $piece->toArray()['weight']);
     }
 
     /** @test */
@@ -56,7 +67,7 @@ class PieceTest extends TestCase
         $this->assertIsArray($array);
         $this->assertEquals('LARGE', $array['parcelType']);
         $this->assertArrayNotHasKey('parcel_type', $array);
-        $this->assertEquals(20, $array['weight']);
         $this->assertSame(10, $array['quantity']);
+        $this->assertSame(20, $array['weight']);
     }
 }


### PR DESCRIPTION
Make sure `quantity` and `weight` are properly casted to `integer` values.