### PR TITLE
Refactor pieces class.

### DIFF
--- a/src/Resources/Parcel.php
+++ b/src/Resources/Parcel.php
@@ -177,7 +177,7 @@ class Parcel extends BaseResource
             return;
         }
 
-        $this->pieces->setPiecesAttribute($value);
+        $this->pieces = new Pieces($value);
     }
 
     /**

--- a/src/Resources/Pieces.php
+++ b/src/Resources/Pieces.php
@@ -12,13 +12,13 @@ class Pieces extends BaseResource
     protected $items = [];
 
     /**
-     * Set the pieces.
+     * Create a new Pieces resource.
      *
-     * @param  array  $pieces
+     * @param  array  $attributes
      */
-    public function setPiecesAttribute(array $pieces)
+    public function __construct(array $attributes = [])
     {
-        foreach ($pieces as $piece) {
+        foreach ($attributes as $piece) {
             $this->add($piece);
         }
     }

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -211,29 +211,6 @@ class ParcelTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_the_pieces_by_passing_a_pieces_object()
-    {
-        $pieces = new Pieces([
-            'pieces' => [
-                [
-                    'parcel_type' => Piece::PARCEL_TYPE_SMALL,
-                    'quantity' => 1,
-                    'weight' => 1,
-                ],
-            ],
-        ]);
-
-        $parcel = new Parcel([
-            'pieces' => $pieces,
-        ]);
-
-        $this->assertInstanceOf(Piece::class, $parcel->pieces->items[0]);
-        $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $parcel->pieces->items[0]->parcel_type);
-        $this->assertEquals(1, $parcel->pieces->items[0]->quantity);
-        $this->assertEquals(1, $parcel->pieces->items[0]->weight);
-    }
-
-    /** @test */
     public function it_sets_the_pieces_to_a_default_value_when_pieces_is_empty()
     {
         $parcel = new Parcel([

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -92,6 +92,18 @@ class ParcelTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_the_pieces_by_passing_a_pieces_object()
+    {
+        $pieces = new Pieces;
+
+        $parcel = new Parcel([
+            'pieces' => $pieces,
+        ]);
+
+        $this->assertSame($pieces, $parcel->pieces);
+    }
+
+    /** @test */
     public function it_can_set_a_label_description()
     {
         $parcel = new Parcel();
@@ -196,29 +208,6 @@ class ParcelTest extends TestCase
         $parcel = new Parcel();
 
         $this->assertSame($parcel, $parcel->servicePoint('8004-NL-272403'));
-    }
-
-    /** @test */
-    public function it_can_set_the_pieces_by_passing_a_pieces_object()
-    {
-        $pieces = new Pieces([
-            'pieces' => [
-                [
-                    'parcel_type' => Piece::PARCEL_TYPE_SMALL,
-                    'quantity' => 1,
-                    'weight' => 1,
-                ],
-            ],
-        ]);
-
-        $parcel = new Parcel([
-            'pieces' => $pieces,
-        ]);
-
-        $this->assertInstanceOf(Piece::class, $parcel->pieces->items[0]);
-        $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $parcel->pieces->items[0]->parcel_type);
-        $this->assertEquals(1, $parcel->pieces->items[0]->quantity);
-        $this->assertEquals(1, $parcel->pieces->items[0]->weight);
     }
 
     /** @test */

--- a/tests/Unit/Resources/PiecesTest.php
+++ b/tests/Unit/Resources/PiecesTest.php
@@ -9,45 +9,14 @@ use Mvdnbrk\DhlParcel\Tests\TestCase;
 class PiecesTest extends TestCase
 {
     /** @test */
-    public function creating_a_new_pieces_resource_with_array()
-    {
-        $pieces = new Pieces([
-            'pieces' => [
-                [
-                    'parcel_type' => Piece::PARCEL_TYPE_SMALL,
-                    'quantity' => 1,
-                    'weight' => 1,
-                ],
-            ],
-        ]);
-
-        $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $pieces->items[0]->parcel_type);
-        $this->assertEquals(1, $pieces->items[0]->quantity);
-        $this->assertEquals(1, $pieces->items[0]->weight);
-    }
-
-    /** @test */
-    public function creating_a_new_pieces_resource_with_array_of_piece_objects()
-    {
-        $pieces = new Pieces([
-            'pieces' => [
-                new Piece,
-            ],
-        ]);
-
-        $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $pieces->items[0]->parcel_type);
-        $this->assertEquals(1, $pieces->items[0]->quantity);
-    }
-
-    /** @test */
-    public function it_can_add_a_new_piece_object()
+    public function it_can_add_a_new_piece_with_a_piece_object()
     {
         $pieces = new Pieces;
 
         $pieces->add(new Piece);
 
-        $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $pieces->items[0]->parcel_type);
-        $this->assertEquals(1, $pieces->items[0]->quantity);
+        $this->assertCount(1, $pieces->items);
+        $this->assertInstanceOf(Piece::class, $pieces->items[0]);
     }
 
     /** @test */
@@ -61,21 +30,58 @@ class PiecesTest extends TestCase
             'weight' => 1,
         ]);
 
+        $this->assertCount(1, $pieces->items);
         $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $pieces->items[0]->parcel_type);
-        $this->assertEquals(1, $pieces->items[0]->quantity);
-        $this->assertEquals(1, $pieces->items[0]->weight);
+        $this->assertSame(1, $pieces->items[0]->quantity);
+        $this->assertSame(1, $pieces->items[0]->weight);
+    }
+
+    /** @test */
+    public function creating_a_new_pieces_resource_with_array()
+    {
+        $pieces = new Pieces([
+            [
+                'parcel_type' => Piece::PARCEL_TYPE_SMALL,
+                'quantity' => 1,
+                'weight' => 1,
+            ],
+            [
+                'parcel_type' => Piece::PARCEL_TYPE_MEDIUM,
+                'quantity' => 2,
+                'weight' => 2,
+            ],
+        ]);
+
+        $this->assertCount(2, $pieces->items);
+        $this->assertInstanceOf(Piece::class, $pieces->items[0]);
+        $this->assertInstanceOf(Piece::class, $pieces->items[1]);
+        $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $pieces->items[0]->parcel_type);
+        $this->assertSame(1, $pieces->items[0]->quantity);
+        $this->assertSame(1, $pieces->items[0]->weight);
+        $this->assertEquals(Piece::PARCEL_TYPE_MEDIUM, $pieces->items[1]->parcel_type);
+        $this->assertSame(2, $pieces->items[1]->quantity);
+        $this->assertSame(2, $pieces->items[1]->weight);
+    }
+
+    /** @test */
+    public function creating_a_new_pieces_resource_with_array_of_piece_objects()
+    {
+        $pieces = new Pieces([
+            new Piece,
+        ]);
+
+        $this->assertCount(1, $pieces->items);
+        $this->assertInstanceOf(Piece::class, $pieces->items[0]);
     }
 
     /** @test */
     public function to_array()
     {
         $pieces = new Pieces([
-            'pieces' => [
-                [
-                    'parcel_type' => Piece::PARCEL_TYPE_SMALL,
-                    'quantity' => 1,
-                    'weight' => 1,
-                ],
+            [
+                'parcel_type' => Piece::PARCEL_TYPE_SMALL,
+                'quantity' => 1,
+                'weight' => 1,
             ],
         ]);
 
@@ -84,7 +90,7 @@ class PiecesTest extends TestCase
         $this->assertIsArray($array);
         $this->assertIsArray($array[0]);
         $this->assertEquals(Piece::PARCEL_TYPE_SMALL, $array[0]['parcelType']);
-        $this->assertEquals(1, $array[0]['quantity']);
-        $this->assertEquals(1, $array[0]['weight']);
+        $this->assertSame(1, $array[0]['quantity']);
+        $this->assertSame(1, $array[0]['weight']);
     }
 }


### PR DESCRIPTION
It doesn't make sense to have a `setPiecesAttribute` on the `Pieces` class.

This PR changes this behavior and makes it possible to construct a `Pieces` class with an array.

/ping @jacobdekeizer 

