### PR TITLE
Add a barcode alias for tracker_code.

### DIFF
--- a/src/Resources/ShipmentPiece.php
+++ b/src/Resources/ShipmentPiece.php
@@ -39,4 +39,14 @@ class ShipmentPiece extends BaseResource
     {
         $this->piece_number = $value;
     }
+
+    /**
+     * Get the barcode. Alias for tracker_code.
+     *
+     * @return string
+     */
+    public function getBarcodeAttribute()
+    {
+        return $this->tracker_code;
+    }
 }

--- a/tests/Unit/Resources/ShipmentPieceTest.php
+++ b/tests/Unit/Resources/ShipmentPieceTest.php
@@ -26,6 +26,16 @@ class ShipmentPieceTest extends TestCase
     }
 
     /** @test */
+    public function barcode_may_be_used_as_an_alias_for_tracker_code()
+    {
+        $piece = new ShipmentPiece([
+            'tracker_code' => 'SAMPLE0000001234',
+        ]);
+
+        $this->assertEquals('SAMPLE0000001234', $piece->barcode);
+    }
+
+    /** @test */
     public function piece_number_should_be_converted_to_an_integer()
     {
         $piece = new ShipmentPiece([


### PR DESCRIPTION
This PR adds a an alias so you can use `barcode` instead of the `tracker_code` attribute:

```php
$shipmentPiece->barcode
```