### PR TITLE
make the servicepoint country configurable

### DIFF
--- a/src/Endpoints/ServicePoints.php
+++ b/src/Endpoints/ServicePoints.php
@@ -19,6 +19,12 @@ class ServicePoints extends BaseEndpoint
     public $housenumber;
 
     /**
+     * @var string
+     */
+    public $country = "NL";
+
+
+    /**
      * Get a collection of service points.
      *
      * @param  array  $filters
@@ -28,7 +34,7 @@ class ServicePoints extends BaseEndpoint
     {
         $response = $this->performApiCall(
             'GET',
-            'parcel-shop-locations/NL'.$this->buildQueryString($this->getFilters($filters))
+            'parcel-shop-locations/'. $this->country . $this->buildQueryString($this->getFilters($filters))
         );
 
         $collection = new Collection();
@@ -77,6 +83,19 @@ class ServicePoints extends BaseEndpoint
     public function setPostalCode(string $value)
     {
         $this->postal_code = preg_replace('/\s+/', '', Str::upper($value));
+
+        return $this;
+    }
+    
+     /**
+     * Set the country.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function setCountry(string $value)
+    {
+        $this->country = $value;
 
         return $this;
     }

--- a/tests/Feature/Endpoints/ServicePointsTest.php
+++ b/tests/Feature/Endpoints/ServicePointsTest.php
@@ -42,4 +42,13 @@ class ServicePointsTest extends TestCase
         $this->assertInstanceOf(Collection::class, $servicepoints);
         $this->assertInstanceOf(ServicePointResource::class, $servicepoints->first());
     }
+
+    /** @test */
+    public function it_can_retrieve_service_points_with_country()
+    {
+        $servicepoints = $this->client->servicePoints->setPostalcode('2000')->setHousenumber('1')->setCountry('BE')->get();
+
+        $this->assertInstanceOf(Collection::class, $servicepoints);
+        $this->assertInstanceOf(ServicePointResource::class, $servicepoints->first());
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I needed a way to fetch dhl servicepoints for different countries (mainly Belgium, Germany and Netherlands)

I added the country property in the endpoint file, so that it's configurable, the default is set to NL so that it does not break the existing code.

I tested it on my live store.


What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
- [X] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
