### PR TITLE
Add support for an additional address line

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $parcel = new \Mvdnbrk\DhlParcel\Resources\Parcel([
     'sender' => [
         'company_name' => 'Your Company Name',
         'street' => 'Pakketstraat',
+        'additional_address_line' => 'Industrie 9999',
         'number' => '99',
         'postal_code' => '9999AA',
         'city' => 'Amsterdam',

--- a/src/Resources/Address.php
+++ b/src/Resources/Address.php
@@ -12,6 +12,11 @@ class Address extends BaseResource
     public $street;
 
     /**
+     * @var string
+     */
+    public $additional_address_line;
+
+    /**
      * @var int|string
      */
     public $number;
@@ -119,6 +124,11 @@ class Address extends BaseResource
                 return $collection
                     ->put('addition', $this->number_suffix)
                     ->forget('number_suffix');
+            })
+            ->when(! empty($this->additional_address_line), function ($collection) {
+                return $collection
+                    ->put('additionalAddressLine', $this->additional_address_line)
+                    ->forget('additional_address_line');
             })
             ->put('postalCode', $this->postal_code)
             ->put('countryCode', $this->cc)

--- a/tests/Unit/Resources/AddressTest.php
+++ b/tests/Unit/Resources/AddressTest.php
@@ -11,6 +11,7 @@ class AddressTest extends TestCase
     {
         return array_merge([
             'street' => 'Poststraat',
+            'additional_address_line' => 'Industrie 9999',
             'number' => '1',
             'number_suffix' => 'A',
             'postal_code' => '1234AA',
@@ -25,6 +26,7 @@ class AddressTest extends TestCase
     {
         $address = new Address([
             'street' => 'Poststraat',
+            'additional_address_line' => 'Industrie 9999',
             'number' => '1',
             'number_suffix' => 'A',
             'postal_code' => '1234AA',
@@ -34,6 +36,7 @@ class AddressTest extends TestCase
         ]);
 
         $this->assertEquals('Poststraat', $address->street);
+        $this->assertEquals('Industrie 9999', $address->additional_address_line);
         $this->assertEquals('1', $address->number);
         $this->assertEquals('A', $address->number_suffix);
         $this->assertEquals('1234AA', $address->postal_code);
@@ -110,6 +113,7 @@ class AddressTest extends TestCase
     {
         $attributes = [
             'street' => 'Poststraat',
+            'additional_address_line' => 'Industrie 9999',
             'number' => '1',
             'number_suffix' => 'A',
             'postal_code' => '1234AA',
@@ -125,10 +129,12 @@ class AddressTest extends TestCase
         $this->assertIsArray($array);
         $this->assertFalse($array['isBusiness']);
         $this->assertEquals('Poststraat', $array['street']);
+        $this->assertEquals('Industrie 9999', $array['additionalAddressLine']);
         $this->assertEquals('1', $array['number']);
         $this->assertEquals('A', $array['addition']);
         $this->assertEquals('1234AA', $array['postalCode']);
         $this->assertEquals('NL', $array['countryCode']);
+        $this->assertArrayNotHasKey('additional_address_line', $array);
         $this->assertArrayNotHasKey('number_suffix', $array);
         $this->assertArrayNotHasKey('postal_code', $array);
         $this->assertArrayNotHasKey('cc', $array);
@@ -137,5 +143,10 @@ class AddressTest extends TestCase
         $array = $address->toArray();
         $this->assertArrayNotHasKey('addition', $array);
         $this->assertArrayNotHasKey('number_suffix', $array);
+
+        $address->additional_address_line = null;
+        $array = $address->toArray();
+        $this->assertArrayNotHasKey('additionalAddressLine', $array);
+        $this->assertArrayNotHasKey('additional_address_line', $array);
     }
 }


### PR DESCRIPTION
Added support for an additional address line in addresses, this is often required for international shipments and can be useful for NL shipments.

## Description

Added a new property to address, in line with DHL naming and existing code.

## Motivation and context

This code adds a missing feature to the API which DHL provides.

## How has this been tested?

Created a label with an extra line, checked to new line was submitted to DHL.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.
