### PR TITLE
Fix conflicts with `collection` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "tightenco/collect": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
+        "illuminate/collections": "^8.4",
         "phpunit/phpunit": "^8.0 || ^9.3",
         "symfony/var-dumper": "^5.0",
         "vlucas/phpdotenv": "^5.0"

--- a/src/Resources/Piece.php
+++ b/src/Resources/Piece.php
@@ -46,12 +46,10 @@ class Piece extends BaseResource
 
     public function toArray(): array
     {
-        return collect([
+        return array_filter([
             'parcelType' => $this->parcel_type,
             'quantity' => $this->quantity,
             'weight' => $this->weight,
-        ])
-            ->filter()
-            ->all();
+        ]);
     }
 }

--- a/src/Resources/PiecesCollection.php
+++ b/src/Resources/PiecesCollection.php
@@ -34,13 +34,8 @@ class PiecesCollection extends Collection
 
     public function toArray(): array
     {
-        return collect($this->items)
-            ->whenEmpty(function (Collection $collection) {
-                return $collection->push(new Piece);
-            })
-            ->map(function (Piece $piece) {
-                return $piece->toArray();
-            })
-            ->all();
+        return array_map(function ($item) {
+            return $item->toArray();
+        }, empty($this->items) ? [new Piece] : $this->items);
     }
 }


### PR DESCRIPTION
This PR aims to fix conflicts between the `tightenco/collect` and `illuminate/collections` package.

The `tightenco/collect` package is [deprecated](https://github.com/tighten/collect).
So it could be replaced by [illuminate/collections](https://github.com/illuminate/collections), though the latter requires PHP 7.3 while this package still supports PHP 7.2.

For this reason keep the `tightenco` version in for now.

Resolves #50 