### PR TITLE
Add support for evening delivery and extra assurance

### DIFF
--- a/src/Resources/Parcel.php
+++ b/src/Resources/Parcel.php
@@ -55,6 +55,13 @@ class Parcel extends BaseResource
         return $this;
     }
 
+    public function insured(): self
+    {
+        $this->options->insured = true;
+
+        return $this;
+    }
+
     public function signature(): self
     {
         $this->options->signature = true;

--- a/src/Resources/Parcel.php
+++ b/src/Resources/Parcel.php
@@ -55,9 +55,16 @@ class Parcel extends BaseResource
         return $this;
     }
 
-    public function insured(): self
+    public function extraAssurance(): self
     {
-        $this->options->insured = true;
+        $this->options->extra_assurance = true;
+
+        return $this;
+    }
+
+    public function eveningDelivery(): self
+    {
+        $this->options->evening_delivery = true;
 
         return $this;
     }

--- a/src/Resources/ShipmentOptions.php
+++ b/src/Resources/ShipmentOptions.php
@@ -22,6 +22,9 @@ class ShipmentOptions extends BaseResource
     public $only_recipient;
 
     /** @var bool */
+    public $insured;
+
+    /** @var bool */
     public $signature;
 
     public function __construct(array $attributes = [])
@@ -36,6 +39,7 @@ class ShipmentOptions extends BaseResource
         $this->delivery_type = 'DOOR';
         $this->signature = false;
         $this->only_recipient = false;
+        $this->insured = false;
 
         return $this;
     }
@@ -116,6 +120,11 @@ class ShipmentOptions extends BaseResource
             ->when($this->only_recipient, function ($collection) {
                 return $collection->push([
                     'key' => 'NBB',
+                ]);
+            })
+            ->when($this->insured, function ($collection) {
+                return $collection->push([
+                    'key' => 'INS',
                 ]);
             })
             ->all();

--- a/src/Resources/ShipmentOptions.php
+++ b/src/Resources/ShipmentOptions.php
@@ -22,7 +22,10 @@ class ShipmentOptions extends BaseResource
     public $only_recipient;
 
     /** @var bool */
-    public $insured;
+    public $extra_assurance;
+
+    /** @var bool */
+    public $evening_delivery;
 
     /** @var bool */
     public $signature;
@@ -39,7 +42,8 @@ class ShipmentOptions extends BaseResource
         $this->delivery_type = 'DOOR';
         $this->signature = false;
         $this->only_recipient = false;
-        $this->insured = false;
+        $this->extra_assurance = false;
+        $this->evening_delivery = false;
 
         return $this;
     }
@@ -122,9 +126,14 @@ class ShipmentOptions extends BaseResource
                     'key' => 'NBB',
                 ]);
             })
-            ->when($this->insured, function ($collection) {
+            ->when($this->extra_assurance, function ($collection) {
                 return $collection->push([
-                    'key' => 'INS',
+                    'key' => 'EA',
+                ]);
+            })
+            ->when($this->evening_delivery, function ($collection) {
+                return $collection->push([
+                    'key' => 'EVE',
                 ]);
             })
             ->all();

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -50,7 +50,8 @@ class ParcelTest extends TestCase
                 'description' => 'Test 123',
                 'only_recipient' => true,
                 'signature' => true,
-                'insured' => true,
+                'extra_assurance' => true,
+                'evening_delivery' => true,
             ],
             'pieces' => [
                 [
@@ -72,7 +73,8 @@ class ParcelTest extends TestCase
         $this->assertEquals(1, $parcel->pieces->first()->weight);
         $this->assertSame(true, $parcel->options->only_recipient);
         $this->assertSame(true, $parcel->options->signature);
-        $this->assertSame(true, $parcel->options->insured);
+        $this->assertSame(true, $parcel->options->extra_assurance);
+        $this->assertSame(true, $parcel->options->evening_delivery);
     }
 
     /** @test */
@@ -170,23 +172,42 @@ class ParcelTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_a_parcel_to_be_insured()
+    public function it_can_set_a_parcel_to_be_extra_assured()
     {
         $parcel = new Parcel();
 
-        $this->assertFalse($parcel->options->insured);
+        $this->assertFalse($parcel->options->extra_assurance);
 
-        $parcel->insured();
+        $parcel->extraAssurance();
 
-        $this->assertTrue($parcel->options->insured);
+        $this->assertTrue($parcel->options->extra_assurance);
+    }
+    /** @test */
+    public function it_can_set_a_parcel_to_be_evening_delivery()
+    {
+        $parcel = new Parcel();
+
+        $this->assertFalse($parcel->options->evening_delivery);
+
+        $parcel->eveningDelivery();
+
+        $this->assertTrue($parcel->options->evening_delivery);
     }
 
     /** @test */
-    public function calling_the_insured_method_returns_the_same_parcel_instance()
+    public function calling_the_extra_assurance_method_returns_the_same_parcel_instance()
     {
         $parcel = new Parcel();
 
-        $this->assertSame($parcel, $parcel->insured());
+        $this->assertSame($parcel, $parcel->extraAssurance());
+    }
+
+    /** @test */
+    public function calling_the_evening_delivery_method_returns_the_same_parcel_instance()
+    {
+        $parcel = new Parcel();
+
+        $this->assertSame($parcel, $parcel->eveningDelivery());
     }
 
     /** @test */

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -50,6 +50,7 @@ class ParcelTest extends TestCase
                 'description' => 'Test 123',
                 'only_recipient' => true,
                 'signature' => true,
+                'insured' => true,
             ],
             'pieces' => [
                 [
@@ -71,6 +72,7 @@ class ParcelTest extends TestCase
         $this->assertEquals(1, $parcel->pieces->first()->weight);
         $this->assertSame(true, $parcel->options->only_recipient);
         $this->assertSame(true, $parcel->options->signature);
+        $this->assertSame(true, $parcel->options->insured);
     }
 
     /** @test */
@@ -165,6 +167,26 @@ class ParcelTest extends TestCase
         $parcel = new Parcel();
 
         $this->assertSame($parcel, $parcel->onlyRecipient());
+    }
+
+    /** @test */
+    public function it_can_set_a_parcel_to_be_insured()
+    {
+        $parcel = new Parcel();
+
+        $this->assertFalse($parcel->options->insured);
+
+        $parcel->insured();
+
+        $this->assertTrue($parcel->options->insured);
+    }
+
+    /** @test */
+    public function calling_the_insured_method_returns_the_same_parcel_instance()
+    {
+        $parcel = new Parcel();
+
+        $this->assertSame($parcel, $parcel->insured());
     }
 
     /** @test */

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -182,6 +182,7 @@ class ParcelTest extends TestCase
 
         $this->assertTrue($parcel->options->extra_assurance);
     }
+    
     /** @test */
     public function it_can_set_a_parcel_to_be_evening_delivery()
     {

--- a/tests/Unit/Resources/ParcelTest.php
+++ b/tests/Unit/Resources/ParcelTest.php
@@ -182,7 +182,7 @@ class ParcelTest extends TestCase
 
         $this->assertTrue($parcel->options->extra_assurance);
     }
-    
+
     /** @test */
     public function it_can_set_a_parcel_to_be_evening_delivery()
     {

--- a/tests/Unit/Resources/ShipmentOptionsTest.php
+++ b/tests/Unit/Resources/ShipmentOptionsTest.php
@@ -17,7 +17,8 @@ class ShipmentOptionsTest extends TestCase
         $this->assertEquals('Test', $options->label_description);
         $this->assertFalse($options->signature);
         $this->assertFalse($options->only_recipient);
-        $this->assertFalse($options->insured);
+        $this->assertFalse($options->extra_assurance);
+        $this->assertFalse($options->evening_delivery);
     }
 
     /** @test */
@@ -122,10 +123,10 @@ class ShipmentOptionsTest extends TestCase
     }
 
     /** @test */
-    public function to_array_with_insured()
+    public function to_array_with_extra_assurance()
     {
         $options = new ShipmentOptions([
-            'insured' => true,
+            'extra_assurance' => true,
         ]);
 
         $array = $options->toArray();
@@ -137,7 +138,28 @@ class ShipmentOptionsTest extends TestCase
                 'key' => 'DOOR',
             ],
             [
-                'key' => 'INS',
+                'key' => 'EA',
+            ],
+        ], $array);
+    }
+
+    /** @test */
+    public function to_array_with_evening_delivery()
+    {
+        $options = new ShipmentOptions([
+            'evening_delivery' => true,
+        ]);
+
+        $array = $options->toArray();
+
+        $this->assertIsArray($array);
+
+        $this->assertEquals([
+            [
+                'key' => 'DOOR',
+            ],
+            [
+                'key' => 'EVE',
             ],
         ], $array);
     }

--- a/tests/Unit/Resources/ShipmentOptionsTest.php
+++ b/tests/Unit/Resources/ShipmentOptionsTest.php
@@ -17,6 +17,7 @@ class ShipmentOptionsTest extends TestCase
         $this->assertEquals('Test', $options->label_description);
         $this->assertFalse($options->signature);
         $this->assertFalse($options->only_recipient);
+        $this->assertFalse($options->insured);
     }
 
     /** @test */
@@ -116,6 +117,27 @@ class ShipmentOptionsTest extends TestCase
             ],
             [
                 'key' => 'NBB',
+            ],
+        ], $array);
+    }
+
+    /** @test */
+    public function to_array_with_insured()
+    {
+        $options = new ShipmentOptions([
+            'insured' => true,
+        ]);
+
+        $array = $options->toArray();
+
+        $this->assertIsArray($array);
+
+        $this->assertEquals([
+            [
+                'key' => 'DOOR',
+            ],
+            [
+                'key' => 'INS',
             ],
         ], $array);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding the insured shipping option

## Motivation and context

I want to create insured shipments, but there was no option available. In the documentation of DHLPARCEL is described that you just need to post INS as a option

## How has this been tested?

Yes, tests are created and tested

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

I hope you also think this is helpful and this PR can be merged! :)

Thanks in advance!
