### PR TITLE
Fixed bug to retrieve PDF shipment label

### DIFF
--- a/src/Endpoints/BaseEndpoint.php
+++ b/src/Endpoints/BaseEndpoint.php
@@ -56,7 +56,7 @@ abstract class BaseEndpoint
             $this->getRequestHeaders($requestHeaders)
         );
 
-        if (collect($response->getHeader('Content-Type'))->first() == 'application/octet-stream') {
+        if (collect($response->getHeader('Content-Type'))->first() == 'application/pdf') {
             return $response->getBody()->getContents();
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Something has changed in de DHL API which made retrieving shipment labels impossible.

## Motivation and context

fixes #64

## How has this been tested?

Current unit test were failing, so no new test were needed to test this.

```
1) Mvdnbrk\DhlParcel\Tests\Feature\Endpoints\LabelsTest::get_a_label_by_id
Mvdnbrk\DhlParcel\Exceptions\DhlParcelException: Unable to decode DHL Parcel response: '%PDF-1.4
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
