### PR TITLE
Use illuminate collections to support Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 7.4, 7.3, 7.2]
+        php: [8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/guzzle": "^6.4 || ^7.1",
         "lcobucci/jwt": "^3.4 || ^4.0",
         "ramsey/uuid": "^4.0",
-        "tightenco/collect": "^5.8 || ^6.0 || ^7.0 || ^8.0"
+        "illuminate/collections": "^11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.4",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.2",
         "ext-json": "*",
         "composer/ca-bundle": "^1.2",
         "guzzlehttp/guzzle": "^6.4 || ^7.1",

--- a/src/Endpoints/ServicePoints.php
+++ b/src/Endpoints/ServicePoints.php
@@ -2,9 +2,9 @@
 
 namespace Mvdnbrk\DhlParcel\Endpoints;
 
+use Illuminate\Support\Collection;
 use Mvdnbrk\DhlParcel\Resources\ServicePoint as ServicePointResource;
 use Mvdnbrk\DhlParcel\Support\Str;
-use Tightenco\Collect\Support\Collection;
 
 class ServicePoints extends BaseEndpoint
 {

--- a/src/Resources/PiecesCollection.php
+++ b/src/Resources/PiecesCollection.php
@@ -2,7 +2,7 @@
 
 namespace Mvdnbrk\DhlParcel\Resources;
 
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class PiecesCollection extends Collection
 {

--- a/src/Resources/Shipment.php
+++ b/src/Resources/Shipment.php
@@ -2,7 +2,7 @@
 
 namespace Mvdnbrk\DhlParcel\Resources;
 
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class Shipment extends BaseResource
 {
@@ -15,7 +15,7 @@ class Shipment extends BaseResource
     /** @var string */
     public $label_id;
 
-    /** @var \Tightenco\Collect\Support\Collection */
+    /** @var Collection */
     public $pieces;
 
     public function __construct(array $attributes = [])

--- a/tests/Feature/Endpoints/ServicePointsTest.php
+++ b/tests/Feature/Endpoints/ServicePointsTest.php
@@ -2,10 +2,10 @@
 
 namespace Mvdnbrk\DhlParcel\Tests\Feature\Endpoints;
 
+use Illuminate\Support\Collection;
 use Mvdnbrk\DhlParcel\Endpoints\ServicePoints;
 use Mvdnbrk\DhlParcel\Resources\ServicePoint as ServicePointResource;
 use Mvdnbrk\DhlParcel\Tests\TestCase;
-use Tightenco\Collect\Support\Collection;
 
 /** @group integration */
 class ServicePointsTest extends TestCase

--- a/tests/Unit/Resources/ShipmentTest.php
+++ b/tests/Unit/Resources/ShipmentTest.php
@@ -2,9 +2,9 @@
 
 namespace Mvdnbrk\DhlParcel\Tests\Unit\Resources;
 
+use Illuminate\Support\Collection;
 use Mvdnbrk\DhlParcel\Resources\Shipment;
 use Mvdnbrk\DhlParcel\Tests\TestCase;
-use Tightenco\Collect\Support\Collection;
 
 class ShipmentTest extends TestCase
 {


### PR DESCRIPTION
## Description

To resolve dependency conflicts for Laravel 11 and ensure ongoing support, I have replaced the `tightenco/collect` package with the `illuminate/collections` package.

## Motivation and context

- Dependency Conflict:
The `laravel/framework` (version v11.36.1) requires `symfony/var-dumper ^7.0.3`, which conflicts with the `tightenco/collect` package. The `tightenco` package requires `symfony/var-dumper versions ^3.4 || ^4.0 || ^5.0 || ^6.0`, causing a version mismatch.

- Abandonment of `tightenco` package:
  The `tightenco/collect` package is no longer maintained.

## How has this been tested?

The unit tests are still working and I tested it in my own project. The new changes require `^php 8.2`, so the current github workflows will fail. I have updated the workflow matrix with the new PHP versions.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.
